### PR TITLE
airstream 0.12.0-M1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ target/
 .js/
 .jvm/
 .idea
+.metals/
+.vscode/
+.bloop/
+metals.sbt
 
 js/yarn.lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Breaking changes in **bold**.
 
 _You can now [sponsor](https://github.com/sponsors/raquo) Laminar / Airstream / Waypoint development!_
 
+#### v0.2.1-M1 – Jan 2021
+Version bump
+scala 2.13.4
+scalajs 1.4.0
+airstream 0.12.0-M1
+url-dsl 0.3.2
+
 #### v0.2.0 – Aug 2020
 
 * **API: Waypoint does not depend on Laminar anymore**

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ inThisBuild(Seq(
   name := "Waypoint",
   normalizedName := "waypoint",
   organization := "com.raquo",
-  scalaVersion := "2.13.1",
-  crossScalaVersions := Seq("2.12.10", "2.13.1")
+  scalaVersion := "2.13.4",
+  crossScalaVersions := Seq("2.12.13", "2.13.4")
 ))
 
 // @TODO[WTF] Why can't this be inside releaseSettings?
@@ -73,7 +73,7 @@ lazy val scalacSettings = Seq(
 
 lazy val commonSettings = releaseSettings ++ scalacSettings ++ Seq(
   libraryDependencies ++= Seq(
-    "be.doeraene" %%% "url-dsl" % "0.2.0",
+    "be.doeraene" %%% "url-dsl" % "0.3.2",
     "com.lihaoyi" %%% "upickle" % "1.0.0" % Test,
     "org.scalatest" %%% "scalatest" % "3.1.1" % Test,
   )
@@ -95,8 +95,8 @@ lazy val waypoint = crossProject(JSPlatform, JVMPlatform).in(file("."))
     useYarn := true,
     libraryDependencies ++= Seq(
       "org.scala-js" %%% "scalajs-dom" % "1.1.0",
-      "com.raquo" %%% "airstream" % "0.10.0",
-      "com.raquo" %%% "laminar" % "0.10.2" % Test,
+      "com.raquo" %%% "airstream" % "0.12.0-M1",
+      "com.raquo" %%% "laminar" % "0.12.0-M1" % Test,
     )
   )
 

--- a/js/src/main/scala/com/raquo/waypoint/CollectPageSignalRenderer.scala
+++ b/js/src/main/scala/com/raquo/waypoint/CollectPageSignalRenderer.scala
@@ -1,6 +1,7 @@
 package com.raquo.waypoint
 
-import com.raquo.airstream.signal.{Signal, Var}
+import com.raquo.airstream.core.Signal
+import com.raquo.airstream.state.Var
 
 /** The job of this renderer is to provide Signal[OutPage] => View
   * instead of the more obvious but less efficient Signal[OutPage] => Signal[View]

--- a/js/src/main/scala/com/raquo/waypoint/Router.scala
+++ b/js/src/main/scala/com/raquo/waypoint/Router.scala
@@ -1,8 +1,8 @@
 package com.raquo.waypoint
 
-import com.raquo.airstream.eventstream.EventStream
+import com.raquo.airstream.core.EventStream
 import com.raquo.airstream.ownership.Owner
-import com.raquo.airstream.signal.{StrictSignal, Var}
+import com.raquo.airstream.state.{StrictSignal, Var}
 import org.scalajs.dom
 
 import scala.util.Try

--- a/js/src/main/scala/com/raquo/waypoint/SplitRender.scala
+++ b/js/src/main/scala/com/raquo/waypoint/SplitRender.scala
@@ -1,6 +1,6 @@
 package com.raquo.waypoint
 
-import com.raquo.airstream.signal.Signal
+import com.raquo.airstream.core.Signal
 
 import scala.reflect.ClassTag
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.17.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 

--- a/shared/src/main/scala/com/raquo/waypoint/package.scala
+++ b/shared/src/main/scala/com/raquo/waypoint/package.scala
@@ -14,6 +14,13 @@ package object waypoint {
   val root: PathSegment[Unit, DummyError] =
     PathSegment.root
 
+  implicit final def unaryPathSegment[T](
+        t: T
+    )(
+        implicit fromString: FromString[T, DummyError],
+        printer: Printer[T],
+    ): PathSegment[Unit, DummyError] = PathSegment.unaryPathSegment(t)
+
   def segment[Arg](implicit fromString: FromString[Arg, DummyError], printer: Printer[Arg]): PathSegment[Arg, DummyError] =
     PathSegment.segment[Arg, DummyError]
 


### PR DESCRIPTION
Waypoint 0.2 was incompatible with laminar 0.12.0-M1. This PR has changes to waypoint for airstream 0.12.0-M1 plus other dependencies version bumps. Tests pass and it works correctly in my app with airstream and laminar 0.12.0-M1. No changes in my app were required related to waypoint upgrade. If you could review it and release so others that want to test laminar 0.12.0-M1.
