### PR TITLE
Probably don't merge - Upickle 3 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ sealed trait Page
 case class UserPage(userId: Int) extends Page
 case object LoginPage extends Page
 
-// For upickle 3 series you'll want
+// For upickle 3 series an explicit derivation is required
 // case object LoginPage extends Page derives ReadWriter
 
 implicit val UserPageRW: ReadWriter[UserPage] = macroRW

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ sealed trait Page
 case class UserPage(userId: Int) extends Page
 case object LoginPage extends Page
 
+// For upickle 3 series you'll want
+// case object LoginPage extends Page derives ReadWriter
+
 implicit val UserPageRW: ReadWriter[UserPage] = macroRW
 implicit val rw: ReadWriter[Page] = macroRW
 


### PR DESCRIPTION
I lost quite a bit of time, figuring out that a transitive change to upickle 3 required explicit derivation of `case objects`. 

This is a vey quick docs PR in case the knowledge saves time. 