### PR TITLE
Introduce WaypointException to improve developer experience

### DIFF
--- a/js/src/main/scala/com/raquo/waypoint/Router.scala
+++ b/js/src/main/scala/com/raquo/waypoint/Router.scala
@@ -82,7 +82,7 @@ class Router[BasePage](
 
     lazy val initialPage = {
       if (!Utils.absoluteUrlMatchesOrigin(origin, url = initialUrl)) {
-        throw new Exception(s"Initial URL does not belong to origin: $initialUrl vs $origin/ - Use the full absolute URL for initialUrl, and don't include the trailing slash in origin")
+        throw new WaypointException(s"Initial URL does not belong to origin: $initialUrl vs $origin/ - Use the full absolute URL for initialUrl, and don't include the trailing slash in origin")
       }
 
       val maybeInitialRoutePage = pageForAbsoluteUrl(initialUrl)
@@ -135,7 +135,7 @@ class Router[BasePage](
   /** @throws Exception when url is not relative or is malformed */
   def pageForRelativeUrl(url: String): Option[BasePage] = {
     if (!Utils.isRelative(url)) {
-      throw new Exception("Relative URL must be relative to the origin, i.e. it must start with /, whereas `$url` was given.")
+      throw new WaypointException("Relative URL must be relative to the origin, i.e. it must start with /, whereas `$url` was given.")
     }
     var page: Option[BasePage] = None
     routes.exists { route =>
@@ -163,7 +163,7 @@ class Router[BasePage](
       url = route.relativeUrlForPage(page)
       url.isDefined
     }
-    url.getOrElse(throw new Exception(s"Router has no route for this page: $page"))
+    url.getOrElse(throw new WaypointException(s"Router has no route for this page: $page"))
   }
 
   // @TODO[Naming] Rename {push,replace}State to {push,replace}Page?
@@ -346,7 +346,7 @@ object Router {
   }
 
   private val throwOnUnknownUrl = (url: String) => {
-    throw new Exception("Unable to parse URL into a Page, it does not match any routes: " + url)
+    throw new WaypointException("Unable to parse URL into a Page, it does not match any routes: " + url)
   }
 
   /** History State can be any serializable JS value. Could be a string, a plain object, etc.
@@ -354,7 +354,7 @@ object Router {
     */
   private val throwOnInvalidState = (state: Any) => {
     // @TODO `null` is needed to work around https://github.com/lampepfl/dotty/issues/11943, drop it later
-    throw new Exception("Unable to deserialize history state: " + JSON.stringify(state.asInstanceOf[js.Any], null))
+    throw new WaypointException("Unable to deserialize history state: " + JSON.stringify(state.asInstanceOf[js.Any], null))
   }
 
   /** In Firefox, `file://` URLs have "null" (a string) as location.origin instead of "file://" like in Chrome or Safari.

--- a/js/src/main/scala/com/raquo/waypoint/SplitRender.scala
+++ b/js/src/main/scala/com/raquo/waypoint/SplitRender.scala
@@ -76,7 +76,7 @@ case class SplitRender[Page, View](
         }
       }
 
-      nextView.getOrElse(throw new Exception("Page did not match any renderer: " + nextPage.toString))
+      nextView.getOrElse(throw new WaypointException("Page did not match any renderer: " + nextPage.toString))
     }
   }
 }

--- a/shared/src/main/scala/com/raquo/waypoint/Route.scala
+++ b/shared/src/main/scala/com/raquo/waypoint/Route.scala
@@ -18,7 +18,7 @@ sealed abstract class Route[Page, Args] private[waypoint] (
   basePath: String
 ) {
   if (basePath.nonEmpty && !basePath.startsWith("/")) {
-    throw new Exception(s"Route's basePath, when not empty, must start with `/`. basePath is `$basePath` for this route.")
+    throw new WaypointException(s"Route's basePath, when not empty, must start with `/`. basePath is `$basePath` for this route.")
   }
 
   protected val matchEncodePF: PartialFunction[Any, Args]
@@ -45,7 +45,7 @@ sealed abstract class Route[Page, Args] private[waypoint] (
     */
   def pageForAbsoluteUrl(origin: String, url: String): Option[Page] = {
     if (origin == "null") {
-      throw new Exception("pageForAbsoluteUrl was provided with a \"null\" origin. See https://github.com/raquo/Waypoint#firefox-and-file-urls")
+      throw new WaypointException("pageForAbsoluteUrl was provided with a \"null\" origin. See https://github.com/raquo/Waypoint#firefox-and-file-urls")
     }
     val originMatches = Utils.absoluteUrlMatchesOrigin(origin, url)
     val urlToMatch = if (originMatches) url.substring(origin.length) else url
@@ -64,10 +64,10 @@ sealed abstract class Route[Page, Args] private[waypoint] (
     */
   def pageForRelativeUrl(origin: String, url: String): Option[Page] = {
     if (origin == "null") {
-      throw new Exception("pageForRelativeUrl was provided with a \"null\" origin. See https://github.com/raquo/Waypoint#firefox-and-file-urls")
+      throw new WaypointException("pageForRelativeUrl was provided with a \"null\" origin. See https://github.com/raquo/Waypoint#firefox-and-file-urls")
     }
     if (!Utils.isRelative(url)) {
-      throw new Exception(s"Relative URL must be relative to the origin, i.e. it must start with /, whereas `$url` was given.")
+      throw new WaypointException(s"Relative URL must be relative to the origin, i.e. it must start with /, whereas `$url` was given.")
     }
     if (url.startsWith(basePath)) {
       val urlWithoutBasePath = url.substring(basePath.length)

--- a/shared/src/main/scala/com/raquo/waypoint/Utils.scala
+++ b/shared/src/main/scala/com/raquo/waypoint/Utils.scala
@@ -15,7 +15,7 @@ object Utils {
     if (absoluteUrlMatchesOrigin(origin, absoluteUrl)) {
       absoluteUrl.substring(origin.length)
     } else {
-      throw new Exception(s"Can not make `$absoluteUrl` into relative URL, origin does not match `$origin`.")
+      throw new WaypointException(s"Can not make `$absoluteUrl` into relative URL, origin does not match `$origin`.")
     }
   }
 

--- a/shared/src/main/scala/com/raquo/waypoint/WaypointException.scala
+++ b/shared/src/main/scala/com/raquo/waypoint/WaypointException.scala
@@ -1,0 +1,9 @@
+package com.raquo.waypoint
+
+/**
+ * Prefixes the exception message to make it clear that this is a Waypoint exception.
+ *
+ * When you are in ScalaJS production build and the source maps are not loaded, it is quite hard
+ * to tell where an exception comes from.
+ */
+class WaypointException(message: String) extends Exception(s"[Waypoint] $message")

--- a/shared/src/main/scala/com/raquo/waypoint/WaypointException.scala
+++ b/shared/src/main/scala/com/raquo/waypoint/WaypointException.scala
@@ -1,9 +1,3 @@
 package com.raquo.waypoint
 
-/**
- * Prefixes the exception message to make it clear that this is a Waypoint exception.
- *
- * When you are in ScalaJS production build and the source maps are not loaded, it is quite hard
- * to tell where an exception comes from.
- */
 class WaypointException(message: String) extends Exception(s"[Waypoint] $message")


### PR DESCRIPTION
When you are in ScalaJS production build and the source maps are not loaded, it is quite hard to tell where an exception comes from.

This helps by prefixing the error message with "[Waypoint] ".