### PR TITLE
Fix `Utils.absoluteUrlMatchesOrigin` for environments that do not add '/' to the end of URL

### DIFF
--- a/shared/src/main/scala/com/raquo/waypoint/Utils.scala
+++ b/shared/src/main/scala/com/raquo/waypoint/Utils.scala
@@ -8,7 +8,9 @@ object Utils {
   }
 
   @inline private[waypoint] def absoluteUrlMatchesOrigin(origin: String, url: String): Boolean = {
-    url.startsWith(origin + "/")
+    // Not all browsers (like Tauri) add '/' to the end of the URL automatically, so we also check for 
+    // an exact match.
+    url == origin || url.startsWith(origin + "/")
   }
 
   private[waypoint] def makeRelativeUrl(origin: String, absoluteUrl: String): String = {


### PR DESCRIPTION
As discussed in https://discordapp.com/channels/1020225759610163220/1020226231834255390/1359957521959227452